### PR TITLE
Fix incorrect date sorting in chat list view

### DIFF
--- a/Amazon Bedrock Client for Mac/Views/SidebarView.swift
+++ b/Amazon Bedrock Client for Mac/Views/SidebarView.swift
@@ -36,10 +36,24 @@ struct SidebarView: View {
     // Timer to update chat list periodically
     let timer = Timer.publish(every: 60, on: .main, in: .common).autoconnect()
     
+    private let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM dd, yyyy"
+        return formatter
+    }()
+    
+    private var sortedDateKeys: [String] {
+        organizedChatModels.keys
+            .compactMap { dateFormatter.date(from: $0) }
+            .sorted()
+            .reversed()
+            .map { dateFormatter.string(from: $0) }
+    }
+    
     var body: some View {
         List {
             newChatSection
-            ForEach(organizedChatModels.keys.sorted().reversed(), id: \.self) { dateKey in
+            ForEach(sortedDateKeys, id: \.self) { dateKey in
                 Section(header: Text(dateKey)) {
                     ForEach(organizedChatModels[dateKey] ?? [], id: \.self) { chat in
                         chatRowView(for: chat)


### PR DESCRIPTION
The previous implementation of sorting dates in the chat list view was causing incorrect ordering, where dates were not properly sorted in descending order. This issue was due to the lexicographic string sorting, which compares strings character by character based on their Unicode code point values, rather than treating them as dates.