### PR TITLE
CodeBlock visual refresh and copy button

### DIFF
--- a/Amazon Bedrock Client for Mac.xcodeproj/project.pbxproj
+++ b/Amazon Bedrock Client for Mac.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5BC0DA4A2BC5BDE20019C74D /* CodeBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC0DA492BC5BDE20019C74D /* CodeBlockView.swift */; };
 		7907BEAA2ACD87A200C4D500 /* Amazon_Bedrock_Client_for_MacTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7907BEA92ACD87A200C4D500 /* Amazon_Bedrock_Client_for_MacTests.swift */; };
 		7907BEB42ACD87A200C4D500 /* Amazon_Bedrock_Client_for_MacUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7907BEB32ACD87A200C4D500 /* Amazon_Bedrock_Client_for_MacUITests.swift */; };
 		7907BEB62ACD87A200C4D500 /* Amazon_Bedrock_Client_for_MacUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7907BEB52ACD87A200C4D500 /* Amazon_Bedrock_Client_for_MacUITestsLaunchTests.swift */; };
@@ -76,6 +77,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		5BC0DA492BC5BDE20019C74D /* CodeBlockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeBlockView.swift; sourceTree = "<group>"; };
 		7907BE942ACD87A100C4D500 /* Amazon Bedrock Debug.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Amazon Bedrock Debug.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7907BEA52ACD87A200C4D500 /* Amazon Bedrock Client for MacTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Amazon Bedrock Client for MacTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7907BEA92ACD87A200C4D500 /* Amazon_Bedrock_Client_for_MacTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Amazon_Bedrock_Client_for_MacTests.swift; sourceTree = "<group>"; };
@@ -287,6 +289,7 @@
 			children = (
 				79610DD32AD22A2F00993D09 /* SidebarView.swift */,
 				79610DD12AD22A2F00993D09 /* HomeView.swift */,
+				5BC0DA492BC5BDE20019C74D /* CodeBlockView.swift */,
 				79610DEC2AD230A200993D09 /* ChatView.swift */,
 				79610DD02AD22A2F00993D09 /* MessageBarView.swift */,
 				79610DD62AD22A2F00993D09 /* MessageView.swift */,
@@ -464,6 +467,7 @@
 				79AFC17E2AD23B4800A75ED3 /* ToggleSidebar.swift in Sources */,
 				79610DD72AD22A2F00993D09 /* SidebarSelection.swift in Sources */,
 				7954F8472AD249A7008B03D3 /* SettingManager.swift in Sources */,
+				5BC0DA4A2BC5BDE20019C74D /* CodeBlockView.swift in Sources */,
 				79610DDF2AD22A2F00993D09 /* GithubTheme.swift in Sources */,
 				79610DDD2AD22A2F00993D09 /* TextOutputFormat.swift in Sources */,
 				7954F8432AD247CC008B03D3 /* AWSRegion.swift in Sources */,

--- a/Amazon Bedrock Client for Mac/Views/CodeBlockView.swift
+++ b/Amazon Bedrock Client for Mac/Views/CodeBlockView.swift
@@ -1,0 +1,71 @@
+//
+//  CodeBlock.swift
+//  Amazon Bedrock Client for Mac
+//
+//  Created by Latman, Michael on 4/9/24.
+//
+
+import SwiftUI
+import MarkdownUI
+import Splash
+
+struct CodeBlockView: View {
+  var theme: Splash.Theme
+  var configuration: CodeBlockConfiguration
+  @State var clipboardScale: CGFloat = 1.0
+  @State var clipboardImageName: String = "clipboard"
+  
+  var body: some View {
+    VStack(spacing: 0) {
+      HStack {
+        Text(configuration.language ?? "plain text")
+          .font(.system(.caption, design: .monospaced))
+          .fontWeight(.semibold)
+          .foregroundColor(Color(theme.plainTextColor))
+        Spacer()
+        
+        Image(systemName: clipboardImageName)
+          .foregroundColor(Color(theme.plainTextColor))
+          .scaleEffect(clipboardScale)
+          .animation(.spring(), value: clipboardScale)
+          .onTapGesture {
+            copyToClipboard(configuration.content)
+            clipboardScale = 1.2
+            clipboardImageName = "clipboard.fill"
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+              clipboardScale = 1.0
+              clipboardImageName = "clipboard"
+              
+            }
+          }
+      }
+      .padding(.horizontal)
+      .padding(.vertical, 8)
+      .background {
+        Color(theme.backgroundColor)
+      }
+      
+      Divider()
+      ScrollView(.horizontal) {
+        configuration.label
+          .fixedSize(horizontal: false, vertical: true)
+          .relativeLineSpacing(.em(0.225))
+          .markdownTextStyle {
+            FontFamilyVariant(.monospaced)
+            FontSize(.em(0.85))
+          }
+          .padding(16)
+      }
+      .background(Color.secondaryBackground)
+      .markdownMargin(top: 0, bottom: 16)
+    }
+    .clipShape(RoundedRectangle(cornerRadius: 8))
+    .markdownMargin(top: .zero, bottom: .em(0.8))
+  }
+}
+
+private func copyToClipboard(_ string: String) {
+  let pasteboard = NSPasteboard.general
+  pasteboard.clearContents()
+  pasteboard.setString(string, forType: .string)
+}

--- a/Amazon Bedrock Client for Mac/Views/MessageView.swift
+++ b/Amazon Bedrock Client for Mac/Views/MessageView.swift
@@ -139,8 +139,14 @@ struct MessageView: View {
                     Markdown(message.text)  // Use MarkdownUI directly
                         .id(message.id)
                         .textSelection(.enabled)
-                        .markdownTheme(.gitHub)
+                        .markdownTheme(
+                          .gitHub
+                            .codeBlock() {
+                              CodeBlockView(theme: theme, configuration: $0)
+                            }
+                        )
                         .markdownCodeSyntaxHighlighter(SplashCodeSyntaxHighlighter.splash(theme: self.theme))
+                   
                         .font(.system(size: self.fontSize))
                 } else {
                     HStack(spacing: 10) {


### PR DESCRIPTION
Adds beautiful code blocks inspired by this [example](https://github.com/gonzalezreal/swift-markdown-ui/pull/249/commits/cd09c1eb991923facc4468d136853e144b5d79ec).

**Screenshot**
![Screenshot 2024-04-09 at 15 05 09](https://github.com/aws-samples/amazon-bedrock-client-for-mac/assets/236019/85a858d3-eb85-4785-b2d0-f337916af567)


**Before:**
![Screenshot 2024-04-09 at 15 02 59@2x](https://github.com/aws-samples/amazon-bedrock-client-for-mac/assets/236019/90972aa0-9ec2-4e43-af39-b2c7d7f9634a)

