### PR TITLE
2024-12-19 Add support for Amazon Nova Pro, Lite, Micro Models 

### DIFF
--- a/Amazon Bedrock Client for Mac/Assets.xcassets/Contents.json
+++ b/Amazon Bedrock Client for Mac/Assets.xcassets/Contents.json
@@ -1,4 +1,36 @@
 {
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
   "info" : {
     "author" : "xcode",
     "version" : 1


### PR DESCRIPTION
This pull request adds support for Amazon Nova Pro, Lite, and Micro models (streaming/non-streaming) with Image support (Nova Pro and Nova Lite Models). https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html

*Issue #, if available:* [60](https://github.com/aws-samples/amazon-bedrock-client-for-mac/issues/60)

**Description of changes:**
These changes enable Bedrock Client for Mac to work with Amazon's latest Nova models: 
- Amazon Nova Pro - Model ID: amazon.nova-pro-v1:0
- Amazon Nova Lite - Model ID: amazon.nova-lite-v1:0
- Amazon Nova Micro - Model ID: amazon.nova-micro-v1:0

This pull requests works to ensure consistency with the existing development and structures of the existing chat application. This implementation includes support for both text and image inputs (for Amazon Nova Pro/Lite Models), and streaming/non-streaming capabilities for all Amazon Nova Pro/Lite/Micro models.

**Detailed Changes**
1. BedrockClient.swift:
   - Added Nova model types (novaPro, novaLite, novaMicro) to the ModelType enum
   - Implemented NovaModelParameters struct for Nova-specific request parameters
   - Added invokeNovaModel and invokeNovaModelStream methods
   - Updated getModelType and getModelParameters to handle Nova models
   - Implemented InvokeNovaResponse struct for handling Nova model responses

2. ChatManager.swift:
   - Added Nova-specific history management functions (getNovaHistory, addNovaHistory, cleanupNovaHistory)
   - Integrated Nova history handling into existing chat management workflows
   - Updated deleteHistoryFile to include Nova history

3. ChatViewModel.swift:
   - Implemented handleNovaMessage function for Nova-specific message processing
   - Added invokeNovaModel and invokeNovaModelStream functions
   - Updated existing functions (handleStandardMessage, extractT

extFromChunk) to handle Nova model responses
   - Added support for creating Nova content blocks from MessageData, including image handling

4. Assets.xcassets:
   - Added "AccentColor" to clear warning on Xcode

**Image Support Example Images**
<img width="1863" alt="Nova Pro Image" src="https://github.com/user-attachments/assets/ef870fac-be1d-4947-aa8a-406d1280a125" />
<img width="1863" alt="Nova Lite Image" src="https://github.com/user-attachments/assets/19d7ff41-5bb4-489c-bb5d-0d1ed8d0dc23" />
<img width="1863" alt="Nova Micro Image" src="https://github.com/user-attachments/assets/2ab027e9-00ad-4660-94a1-50c424af90cd" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
