### PR TITLE
Add shortcut to toggle the sidebar

### DIFF
--- a/Amazon Bedrock Client for Mac/Core/Amazon_Bedrock_Client_for_MacApp.swift
+++ b/Amazon Bedrock Client for Mac/Core/Amazon_Bedrock_Client_for_MacApp.swift
@@ -64,6 +64,13 @@ struct Amazon_Bedrock_Client_for_MacApp: App {
             }
             .keyboardShortcut(",", modifiers: [.command])
         }
+        
+        // Add on the menu "View"
+        CommandGroup(before: .toolbar) {
+            Button("View sidebar") {
+                Amazon_Bedrock_Client_for_MacApp.toggleSidebar()
+            }.keyboardShortcut("b", modifiers: [.command])
+        }
     }
     
     private func openBedrockHelp() {
@@ -105,5 +112,9 @@ struct Amazon_Bedrock_Client_for_MacApp: App {
         } catch {
             print("Failed to redirect stdout and stderr to file: \(error)")
         }
+    }
+    
+    static func toggleSidebar() {
+        NSApp.keyWindow?.firstResponder?.tryToPerform(#selector(NSSplitViewController.toggleSidebar(_:)), with: nil)
     }
 }

--- a/Amazon Bedrock Client for Mac/Views/MainView.swift
+++ b/Amazon Bedrock Client for Mac/Views/MainView.swift
@@ -38,7 +38,7 @@ struct MainView: View {
         .onAppear(perform: setup)
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {
-                Button(action: toggleSidebar) {
+                Button(action: Amazon_Bedrock_Client_for_MacApp.toggleSidebar) {
                     Label("Toggle Sidebar", systemImage: "sidebar.left")
                         .labelStyle(IconOnlyLabelStyle())
                 }
@@ -242,11 +242,6 @@ struct MainView: View {
     func deleteCurrentChat() {
         guard case .chat(let chat) = selection else { return }
         selection = chatManager.deleteChat(with: chat.chatId)
-    }
-    
-    private func toggleSidebar() {
-        NSApp.keyWindow?.firstResponder?
-            .tryToPerform(#selector(NSSplitViewController.toggleSidebar(_:)), with: nil)
     }
     
     private func handleMenuSelectionChange(_ newValue: SidebarSelection?) {


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-samples/amazon-bedrock-client-for-mac/issues/69

*Description of changes:*
Add shortcut (command B) to toggle the sidebar.

<img width="665" alt="image" src="https://github.com/user-attachments/assets/a8102a6b-f9a6-4240-836e-4247d5bafb3b" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
