### PR TITLE
Fix prompt caching validation error with PDF documents

### DIFF
--- a/Amazon Bedrock Client for Mac/Models/ChatViewModel.swift
+++ b/Amazon Bedrock Client for Mac/Models/ChatViewModel.swift
@@ -1275,11 +1275,6 @@ class ChatViewModel: ObservableObject {
             
             var contents: [MessageContent] = []
             
-            // Add text content
-            if !message.text.isEmpty {
-                contents.append(.text(message.text))
-            }
-            
             // Add thinking content if present
             if let thinking = message.thinking, !thinking.isEmpty {
                 contents.append(.thinking(MessageContent.ThinkingContent(
@@ -1288,17 +1283,7 @@ class ChatViewModel: ObservableObject {
                 )))
             }
             
-            // Add images if present
-            if let imageBase64Strings = message.imageBase64Strings {
-                for base64String in imageBase64Strings {
-                    contents.append(.image(MessageContent.ImageContent(
-                        format: .jpeg,
-                        base64Data: base64String
-                    )))
-                }
-            }
-            
-            // Add documents if present
+            // Add documents FIRST (before text) to support prompt caching
             if let documentBase64Strings = message.documentBase64Strings,
                let documentFormats = message.documentFormats,
                let documentNames = message.documentNames {
@@ -1311,6 +1296,21 @@ class ChatViewModel: ObservableObject {
                         name: documentNames[i]
                     )))
                 }
+            }
+            
+            // Add images SECOND (before text) to support prompt caching
+            if let imageBase64Strings = message.imageBase64Strings {
+                for base64String in imageBase64Strings {
+                    contents.append(.image(MessageContent.ImageContent(
+                        format: .jpeg,
+                        base64Data: base64String
+                    )))
+                }
+            }
+            
+            // Add text content AFTER documents/images
+            if !message.text.isEmpty {
+                contents.append(.text(message.text))
             }
             
             // Add tool info if present
@@ -1464,22 +1464,8 @@ class ChatViewModel: ObservableObject {
                 contents.append(.thinking(.init(text: thinking, signature: signatureToUse)))
             }
             
-            // Add text content
-            if !message.text.isEmpty {
-                contents.append(.text(message.text))
-            }
-            
-            // Add images if present
-            if let imageBase64Strings = message.imageBase64Strings {
-                for base64String in imageBase64Strings {
-                    contents.append(.image(MessageContent.ImageContent(
-                        format: .jpeg,
-                        base64Data: base64String
-                    )))
-                }
-            }
-            
-            // Add documents if present
+            // Add documents FIRST (before text) to support prompt caching
+            // AWS Bedrock requires cache points to follow text blocks, not document/image blocks
             if let documentBase64Strings = message.documentBase64Strings,
                let documentFormats = message.documentFormats,
                let documentNames = message.documentNames {
@@ -1492,6 +1478,21 @@ class ChatViewModel: ObservableObject {
                         name: documentNames[i]
                     )))
                 }
+            }
+            
+            // Add images SECOND (before text) to support prompt caching
+            if let imageBase64Strings = message.imageBase64Strings {
+                for base64String in imageBase64Strings {
+                    contents.append(.image(MessageContent.ImageContent(
+                        format: .jpeg,
+                        base64Data: base64String
+                    )))
+                }
+            }
+            
+            // Add text content AFTER documents/images
+            if !message.text.isEmpty {
+                contents.append(.text(message.text))
             }
             
             // Handle Tool Use/Result


### PR DESCRIPTION
Fixes #117

Problem:
When attaching PDF (or any other) documents and using prompt caching, AWS Bedrock
returns a ValidationException: 'messages.0.content.2.type: Field required'
This occurs when a cache point immediately follows a document block.

Root Cause:
Message content blocks were constructed in this order:
1. Thinking
2. Text
3. Images
4. Documents

This caused cache points to follow document blocks, triggering the
validation error.

Solution:
Reordered content block construction to place documents and images
before text content in both:
- convertConversationHistoryToBedrockMessages()
- migrateAndGetConversationHistory()

New ordering:
1. Thinking
2. Documents (moved up)
3. Images (moved up)
4. Text (moved down)
5. Tools

This ensures cache points naturally follow text blocks, preventing
the validation error. Based on community workaround pattern.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
