### PR TITLE
feat: Implement unique namespacing for Bedrock tools across servers

### DIFF
--- a/Amazon Bedrock Client for Mac/Managers/ChatManager.swift
+++ b/Amazon Bedrock Client for Mac/Managers/ChatManager.swift
@@ -747,11 +747,19 @@ class ChatManager: ObservableObject {
             return history.messages.map { message in
                 let user = message.role == .user ? "User" : getChatModel(for: chatId)?.name ?? "Assistant"
                 
-                // Convert tool usage
+                // Convert tool usage - de-namespace the tool name for display
                 let toolUse: ToolInfo? = message.toolUse.map { usage in
+                    // Extract original tool name by removing namespace prefix (format: "namespace__toolname")
+                    let displayName: String
+                    if let separatorRange = usage.toolName.range(of: "__") {
+                        displayName = String(usage.toolName[separatorRange.upperBound...])
+                    } else {
+                        displayName = usage.toolName
+                    }
+
                     return ToolInfo(
                         id: usage.toolId,
-                        name: usage.toolName,
+                        name: displayName,
                         input: usage.inputs
                     )
                 }

--- a/Amazon Bedrock Client for Mac/Managers/MCPManager.swift
+++ b/Amazon Bedrock Client for Mac/Managers/MCPManager.swift
@@ -793,8 +793,64 @@ class MCPManager: ObservableObject {
                 infos.append(MCPToolInfo(serverName: serverName, tool: tool, uniqueNamespace: ns))
             }
         }
+
+        // Detect and resolve post-truncation collisions in bedrockToolName
+        infos = resolveBedrockToolNameCollisions(infos)
+
         self.toolInfos = infos
         logger.info("Updated tool info list with \(infos.count) tools from \(availableTools.keys.count) servers")
+    }
+
+    /**
+     * Detects and resolves collisions in bedrockToolName after truncation.
+     * When two tools truncate to the same Bedrock name, appends disambiguation suffixes (_2, _3, etc.)
+     * while staying within the 64-character limit.
+     *
+     * @param infos The list of tool infos to check for collisions
+     * @return Updated list with collision-free bedrockToolNames
+     */
+    private func resolveBedrockToolNameCollisions(_ infos: [MCPToolInfo]) -> [MCPToolInfo] {
+        var bedrockNameCounts: [String: Int] = [:]
+        var bedrockNameUsage: [String: Int] = [:]
+
+        // First pass: count collisions
+        for info in infos {
+            bedrockNameCounts[info.bedrockToolName, default: 0] += 1
+        }
+
+        // Second pass: disambiguate collisions
+        var result: [MCPToolInfo] = []
+        for info in infos {
+            let originalBedrockName = info.bedrockToolName
+
+            if bedrockNameCounts[originalBedrockName] == 1 {
+                // No collision, use as-is
+                result.append(info)
+            } else {
+                // Collision detected - append suffix
+                let occurrence = bedrockNameUsage[originalBedrockName, default: 0] + 1
+                bedrockNameUsage[originalBedrockName] = occurrence
+
+                if occurrence == 1 {
+                    // First occurrence keeps original name
+                    result.append(info)
+                } else {
+                    // Subsequent occurrences get _2, _3, etc.
+                    let suffix = "_\(occurrence)"
+                    let maxLength = 64
+                    let truncatedBase = String(originalBedrockName.prefix(maxLength - suffix.count))
+                    let disambiguatedName = truncatedBase + suffix
+
+                    var updatedInfo = info
+                    updatedInfo.disambiguatedBedrockToolName = disambiguatedName
+                    result.append(updatedInfo)
+
+                    logger.warning("Bedrock tool name collision: '\(originalBedrockName)' → '\(disambiguatedName)' for \(info.serverName).\(info.toolName)")
+                }
+            }
+        }
+
+        return result
     }
     
     /**

--- a/Amazon Bedrock Client for Mac/Managers/MCPManager.swift
+++ b/Amazon Bedrock Client for Mac/Managers/MCPManager.swift
@@ -53,6 +53,9 @@ class MCPManager: ObservableObject {
     // Status tracking
     private var autoStartCompleted = false
     private var connecting: Set<String> = []
+
+    /// Unique namespace per server (serverName -> namespace) for collision-free Bedrock tool names.
+    private var serverUniqueNamespace: [String: String] = [:]
     
     /**
      * Represents the connection status of a server.
@@ -778,12 +781,16 @@ class MCPManager: ObservableObject {
     
     /**
      * Updates the consolidated list of available tools from all connected servers.
+     * Assigns unique namespaces per server so names like "my-server" and "my_server" do not collide.
      */
     private func updateToolInfos() {
+        let serverNames = Array(availableTools.keys)
+        serverUniqueNamespace = assignUniqueNamespaces(serverNames: serverNames)
         var infos: [MCPToolInfo] = []
         for (serverName, tools) in availableTools {
+            let ns = serverUniqueNamespace[serverName] ?? sanitizeServerNameToNamespace(serverName)
             for tool in tools {
-                infos.append(MCPToolInfo(serverName: serverName, tool: tool))
+                infos.append(MCPToolInfo(serverName: serverName, tool: tool, uniqueNamespace: ns))
             }
         }
         self.toolInfos = infos
@@ -1101,24 +1108,29 @@ class MCPManager: ObservableObject {
             
             logger.info("Executing tool '\(name)' with input: \(input)")
             
-            // Find server with the tool
-            var serverWithTool: (name: String, client: Client)? = nil
-            
-            for (serverName, client) in activeClients {
-                if let tools = availableTools[serverName],
-                   tools.contains(where: { $0.name == name }) {
-                    serverWithTool = (serverName, client)
-                    break
+            // Resolve namespaced Bedrock name (e.g. "github__list_issues") to server + original tool name
+            let namespaceToServer: [String: String] = Dictionary(uniqueKeysWithValues: serverUniqueNamespace.map { ($1, $0) })
+            var serverWithTool: (name: String, client: Client, toolName: String)? = nil
+            if let parsed = parseNamespacedToolName(name, namespaceToServer: namespaceToServer),
+               let client = activeClients[parsed.serverName] {
+                serverWithTool = (parsed.serverName, client, parsed.toolName)
+            } else {
+                // Backwards compat: treat name as raw tool name, use first server that has it
+                for (serverName, client) in activeClients {
+                    if availableTools[serverName]?.contains(where: { $0.name == name }) ?? false {
+                        serverWithTool = (serverName, client, name)
+                        break
+                    }
                 }
             }
             
-            if let (serverName, client) = serverWithTool {
-                logger.debug("Executing tool '\(name)' on server '\(serverName)'")
+            if let (serverName, client, toolNameToCall) = serverWithTool {
+                logger.debug("Executing tool '\(toolNameToCall)' on server '\(serverName)'")
                 
                 // Convert input to proper format for tool call with multi-modal support
                 let arguments = try convertToMultiModalArguments(input)
                 
-                let (content, isError) = try await client.callTool(name: name, arguments: arguments)
+                let (content, isError) = try await client.callTool(name: toolNameToCall, arguments: arguments)
                 
                 let extractedContent = extractMultiModalContent(content)
                 

--- a/Amazon Bedrock Client for Mac/Models/ChatViewModel.swift
+++ b/Amazon Bedrock Client for Mac/Models/ChatViewModel.swift
@@ -636,7 +636,7 @@ class ChatViewModel: ObservableObject {
                 let toolSpec = AWSBedrockRuntime.BedrockRuntimeClientTypes.ToolSpecification(
                     description: toolInfo.tool.description,
                     inputSchema: .json(jsonDocument),
-                    name: toolInfo.toolName
+                    name: toolInfo.bedrockToolName
                 )
                 
                 return AWSBedrockRuntime.BedrockRuntimeClientTypes.Tool.toolspec(toolSpec)

--- a/Amazon Bedrock Client for Mac/Models/MCPModels.swift
+++ b/Amazon Bedrock Client for Mac/Models/MCPModels.swift
@@ -95,15 +95,23 @@ private let toolNamespaceDelimiter = "__"
 /// Sanitizes a server name to a Bedrock-safe namespace: lowercase, non-alphanumeric → underscore, collapsed.
 /// Multiple different server names can map to the same value (e.g. "my-server" and "my_server"); use
 /// assignUniqueNamespaces(serverNames:) to get a collision-free mapping.
+/// Bedrock requires tool names to match ^[a-zA-Z][a-zA-Z0-9_-]* so namespaces starting with digits are prefixed with "s_".
 func sanitizeServerNameToNamespace(_ serverName: String) -> String {
     let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_"))
     let folded = serverName.lowercased()
         .unicodeScalars
         .map { allowed.contains($0) ? String($0) : "_" }
         .joined()
-    return folded
+    var result = folded
         .split(separator: "_", omittingEmptySubsequences: true)
         .joined(separator: "_")
+
+    // Bedrock requires tool names to start with a letter, not a digit
+    if let firstChar = result.first, firstChar.isNumber {
+        result = "s_" + result
+    }
+
+    return result
 }
 
 /// Assigns a unique Bedrock-safe namespace to each server name. Collisions (e.g. "my-server" and "my_server")

--- a/Amazon Bedrock Client for Mac/Models/MCPModels.swift
+++ b/Amazon Bedrock Client for Mac/Models/MCPModels.swift
@@ -221,7 +221,10 @@ struct MCPToolInfo: Identifiable, Hashable {
 
     /// Display name for UI (includes server context since tools are shown in a flat list).
     var displayName: String {
-        "\(serverName): \(toolName)"
+        let cleanServerName = serverName
+            .replacingOccurrences(of: "-mcp", with: "", options: .caseInsensitive)
+            .replacingOccurrences(of: "_mcp", with: "", options: .caseInsensitive)
+        return "\(cleanServerName): \(toolName)"
     }
 
     init(serverName: String, tool: Tool, uniqueNamespace: String) {

--- a/Amazon Bedrock Client for Mac/Models/MCPModels.swift
+++ b/Amazon Bedrock Client for Mac/Models/MCPModels.swift
@@ -96,6 +96,10 @@ private let toolNamespaceDelimiter = "__"
 /// Multiple different server names can map to the same value (e.g. "my-server" and "my_server"); use
 /// assignUniqueNamespaces(serverNames:) to get a collision-free mapping.
 /// Bedrock requires tool names to match ^[a-zA-Z][a-zA-Z0-9_-]* so namespaces starting with digits are prefixed with "s_".
+///
+/// INVARIANT: Output never contains "__" (double underscore). This is critical because parseNamespacedToolName()
+/// splits on the first "__" occurrence to separate namespace from tool name. The split(separator: "_", omittingEmptySubsequences: true)
+/// call ensures consecutive underscores are collapsed to a single underscore.
 func sanitizeServerNameToNamespace(_ serverName: String) -> String {
     let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_"))
     let folded = serverName.lowercased()
@@ -109,6 +113,12 @@ func sanitizeServerNameToNamespace(_ serverName: String) -> String {
     // Bedrock requires tool names to start with a letter, not a digit
     if let firstChar = result.first, firstChar.isNumber {
         result = "s_" + result
+    }
+
+    // Defensive check: if "__" somehow appears, fix it and log a warning
+    if result.contains(toolNamespaceDelimiter) {
+        print("Warning: Sanitized namespace '\(result)' contains delimiter '\(toolNamespaceDelimiter)' - fixing to prevent parseNamespacedToolName() breakage")
+        result = result.replacingOccurrences(of: toolNamespaceDelimiter, with: "_")
     }
 
     return result

--- a/Amazon Bedrock Client for Mac/Models/MCPModels.swift
+++ b/Amazon Bedrock Client for Mac/Models/MCPModels.swift
@@ -127,8 +127,43 @@ func assignUniqueNamespaces(serverNames: [String]) -> [String: String] {
 }
 
 /// Returns the tool name sent to Bedrock using an already-assigned unique namespace.
+/// AWS Bedrock enforces a 64-character limit for tool names (pattern: [a-zA-Z0-9_-]+).
+/// If the combined length exceeds this limit, intelligently truncates both parts proportionally.
 func namespacedToolName(namespace: String, toolName: String) -> String {
-    namespace.isEmpty ? toolName : "\(namespace)\(toolNamespaceDelimiter)\(toolName)"
+    guard !namespace.isEmpty else { return toolName }
+
+    let maxLength = 64  // AWS Bedrock API limit for tool names
+    let delimiterLength = toolNamespaceDelimiter.count  // 2 characters ("__")
+    let maxContentLength = maxLength - delimiterLength  // 62 characters available
+
+    // If no truncation needed, return as-is
+    let combined = "\(namespace)\(toolNamespaceDelimiter)\(toolName)"
+    if combined.count <= maxLength {
+        return combined
+    }
+
+    // Need to truncate - allocate proportionally with minimum guarantees
+    let totalOriginalLength = namespace.count + toolName.count
+    let minPartLength = 8  // Minimum chars to preserve meaning
+
+    // Calculate proportional allocation based on original lengths
+    var namespaceAlloc = Int(Double(namespace.count) / Double(totalOriginalLength) * Double(maxContentLength))
+    var toolNameAlloc = maxContentLength - namespaceAlloc
+
+    // Ensure both parts get at least the minimum length
+    if namespaceAlloc < minPartLength {
+        namespaceAlloc = min(minPartLength, maxContentLength - minPartLength)
+        toolNameAlloc = maxContentLength - namespaceAlloc
+    } else if toolNameAlloc < minPartLength {
+        toolNameAlloc = min(minPartLength, maxContentLength - minPartLength)
+        namespaceAlloc = maxContentLength - toolNameAlloc
+    }
+
+    // Truncate and combine
+    let truncatedNamespace = String(namespace.prefix(namespaceAlloc))
+    let truncatedToolName = String(toolName.prefix(toolNameAlloc))
+
+    return "\(truncatedNamespace)\(toolNamespaceDelimiter)\(truncatedToolName)"
 }
 
 /// Parses a Bedrock tool name back to (serverName, originalToolName) using the unique namespace → server map.

--- a/Amazon Bedrock Client for Mac/Models/MCPModels.swift
+++ b/Amazon Bedrock Client for Mac/Models/MCPModels.swift
@@ -153,6 +153,11 @@ func namespacedToolName(namespace: String, toolName: String) -> String {
     let maxLength = 64  // AWS Bedrock API limit for tool names
     let delimiterLength = toolNamespaceDelimiter.count  // 2 characters ("__")
     let maxContentLength = maxLength - delimiterLength  // 62 characters available
+    let minPartLength = 8  // Minimum chars to preserve meaning
+
+    // Precondition: ensure the constants allow valid truncation
+    precondition(maxLength >= 2 * minPartLength + delimiterLength,
+                 "maxLength (\(maxLength)) must be >= 2*minPartLength (\(minPartLength)) + delimiterLength (\(delimiterLength))")
 
     // If no truncation needed, return as-is
     let combined = "\(namespace)\(toolNamespaceDelimiter)\(toolName)"
@@ -162,7 +167,6 @@ func namespacedToolName(namespace: String, toolName: String) -> String {
 
     // Need to truncate - allocate proportionally with minimum guarantees
     let totalOriginalLength = namespace.count + toolName.count
-    let minPartLength = 8  // Minimum chars to preserve meaning
 
     // Calculate proportional allocation based on original lengths
     var namespaceAlloc = Int(Double(namespace.count) / Double(totalOriginalLength) * Double(maxContentLength))

--- a/Amazon Bedrock Client for Mac/Models/MCPModels.swift
+++ b/Amazon Bedrock Client for Mac/Models/MCPModels.swift
@@ -219,6 +219,11 @@ struct MCPToolInfo: Identifiable, Hashable {
         disambiguatedBedrockToolName ?? namespacedToolName(namespace: uniqueNamespace, toolName: toolName)
     }
 
+    /// Display name for UI (includes server context since tools are shown in a flat list).
+    var displayName: String {
+        "\(serverName): \(toolName)"
+    }
+
     init(serverName: String, tool: Tool, uniqueNamespace: String) {
         self.serverName = serverName
         self.toolName = tool.name

--- a/Amazon Bedrock Client for Mac/Models/MCPModels.swift
+++ b/Amazon Bedrock Client for Mac/Models/MCPModels.swift
@@ -211,9 +211,13 @@ struct MCPToolInfo: Identifiable, Hashable {
     var tool: Tool
     /// Unique namespace for this server (from assignUniqueNamespaces); used for Bedrock tool names only.
     var uniqueNamespace: String
+    /// Optional disambiguation suffix applied if bedrockToolName collides after truncation.
+    var disambiguatedBedrockToolName: String? = nil
 
     /// Name sent to Bedrock (namespaced so duplicate tool names across servers are unique and collision-free).
-    var bedrockToolName: String { namespacedToolName(namespace: uniqueNamespace, toolName: toolName) }
+    var bedrockToolName: String {
+        disambiguatedBedrockToolName ?? namespacedToolName(namespace: uniqueNamespace, toolName: toolName)
+    }
 
     init(serverName: String, tool: Tool, uniqueNamespace: String) {
         self.serverName = serverName

--- a/Amazon Bedrock Client for Mac/Tests/MCPModelsTests.swift
+++ b/Amazon Bedrock Client for Mac/Tests/MCPModelsTests.swift
@@ -226,6 +226,80 @@ final class MCPModelsTests: XCTestCase {
         XCTAssertEqual(sanitizeServerNameToNamespace("server___test"), "server_test")
     }
 
+    // MARK: - Edge Case Tests (from PR review feedback)
+
+    func testSanitizeServerName_EmptyString() {
+        let result = sanitizeServerNameToNamespace("")
+        XCTAssertEqual(result, "", "Empty string should return empty string")
+    }
+
+    func testSanitizeServerName_StartsWithDigit() {
+        // Critical: Bedrock requires tool names to start with a letter, not a digit
+        XCTAssertEqual(sanitizeServerNameToNamespace("123service"), "s_123service")
+        XCTAssertEqual(sanitizeServerNameToNamespace("1server"), "s_1server")
+        XCTAssertEqual(sanitizeServerNameToNamespace("99_bottles"), "s_99_bottles")
+    }
+
+    func testSanitizeServerName_AllDigits() {
+        XCTAssertEqual(sanitizeServerNameToNamespace("12345"), "s_12345")
+    }
+
+    func testSanitizeServerName_Unicode() {
+        // Unicode characters should be replaced with underscores
+        XCTAssertEqual(sanitizeServerNameToNamespace("server🚀"), "server_")
+        XCTAssertEqual(sanitizeServerNameToNamespace("日本語"), "___")
+        XCTAssertEqual(sanitizeServerNameToNamespace("café"), "caf_")
+    }
+
+    func testSanitizeServerName_VeryLongName() {
+        let longName = String(repeating: "a", count: 200)
+        let result = sanitizeServerNameToNamespace(longName)
+        XCTAssertEqual(result.count, 200, "Should preserve full length (truncation happens in namespacedToolName)")
+        XCTAssertEqual(result, longName, "Should be unchanged since it's all alphanumeric")
+    }
+
+    func testSanitizeServerName_NoDoubleUnderscore() {
+        // Critical invariant: output must never contain "__" (the delimiter)
+        let testCases = [
+            "my--server",
+            "server___name",
+            "test____service",
+            "a@@@b",
+        ]
+
+        for testCase in testCases {
+            let result = sanitizeServerNameToNamespace(testCase)
+            XCTAssertFalse(result.contains("__"), "Sanitized namespace '\(result)' must not contain '__' delimiter")
+        }
+    }
+
+    func testAssignUniqueNamespaces_EmptyServerName() {
+        let servers = ["", "server1"]
+        let result = assignUniqueNamespaces(serverNames: servers)
+
+        XCTAssertEqual(result[""], "server", "Empty server name should default to 'server'")
+        XCTAssertEqual(result["server1"], "server1")
+    }
+
+    func testAssignUniqueNamespaces_DigitStartingServers() {
+        let servers = ["123service", "456service"]
+        let result = assignUniqueNamespaces(serverNames: servers)
+
+        // Both should get s_ prefix and remain unique
+        XCTAssertEqual(result["123service"], "s_123service")
+        XCTAssertEqual(result["456service"], "s_456service")
+        XCTAssertNotEqual(result["123service"], result["456service"])
+    }
+
+    func testAssignUniqueNamespaces_DigitStartingCollision() {
+        // Edge case: "123server" and "s_123server" both sanitize to "s_123server"
+        let servers = ["123server", "s_123server"]
+        let result = assignUniqueNamespaces(serverNames: servers)
+
+        let namespaces = Set(result.values)
+        XCTAssertEqual(namespaces.count, 2, "Should resolve collision with suffix")
+    }
+
     // MARK: - Unique Namespace Assignment Tests
 
     func testAssignUniqueNamespaces_NoCollisions() {

--- a/Amazon Bedrock Client for Mac/Tests/MCPModelsTests.swift
+++ b/Amazon Bedrock Client for Mac/Tests/MCPModelsTests.swift
@@ -1,0 +1,290 @@
+//
+//  MCPModelsTests.swift
+//  Amazon Bedrock Client for Mac
+//
+//  Tests for MCP model utility functions, particularly tool name namespacing
+//
+
+import XCTest
+@testable import Amazon_Bedrock_Client_for_Mac
+
+final class MCPModelsTests: XCTestCase {
+
+    // MARK: - Tool Name Namespacing Tests
+
+    /// Test that empty namespace returns original tool name
+    func testNamespacedToolName_EmptyNamespace() {
+        let toolName = "test_tool"
+        let result = namespacedToolName(namespace: "", toolName: toolName)
+        XCTAssertEqual(result, toolName, "Empty namespace should return original tool name")
+    }
+
+    /// Test normal case where combined length is well under 64 characters
+    func testNamespacedToolName_NormalLength() {
+        let namespace = "server"
+        let toolName = "read_file"
+        let result = namespacedToolName(namespace: namespace, toolName: toolName)
+        XCTAssertEqual(result, "server__read_file")
+        XCTAssertLessThanOrEqual(result.count, 64)
+    }
+
+    /// Test case where combined length is exactly 64 characters
+    func testNamespacedToolName_ExactlyMaxLength() {
+        // 64 chars total: namespace (30) + delimiter (2) + tool (32)
+        let namespace = String(repeating: "a", count: 30)
+        let toolName = String(repeating: "b", count: 32)
+        let result = namespacedToolName(namespace: namespace, toolName: toolName)
+        XCTAssertEqual(result.count, 64, "Should be exactly 64 characters")
+        XCTAssertTrue(result.contains("__"), "Should contain delimiter")
+    }
+
+    /// Test case where combined length is 63 characters (under limit)
+    func testNamespacedToolName_OneBelowMaxLength() {
+        // 63 chars total: namespace (30) + delimiter (2) + tool (31)
+        let namespace = String(repeating: "a", count: 30)
+        let toolName = String(repeating: "b", count: 31)
+        let result = namespacedToolName(namespace: namespace, toolName: toolName)
+        XCTAssertEqual(result.count, 63, "Should be exactly 63 characters")
+        XCTAssertTrue(result.hasPrefix(namespace + "__"), "Should start with full namespace and delimiter")
+        XCTAssertTrue(result.hasSuffix(toolName), "Should end with full tool name")
+    }
+
+    /// Test case where combined length exceeds 64 characters - requires truncation
+    func testNamespacedToolName_ExceedsMaxLength() {
+        // 70 chars total: namespace (34) + delimiter (2) + tool (34)
+        let namespace = String(repeating: "a", count: 34)
+        let toolName = String(repeating: "b", count: 34)
+        let result = namespacedToolName(namespace: namespace, toolName: toolName)
+
+        XCTAssertLessThanOrEqual(result.count, 64, "Should truncate to 64 characters or less")
+        XCTAssertTrue(result.contains("__"), "Should contain delimiter")
+
+        // Verify structure: namespace part + __ + tool part
+        let parts = result.split(separator: "_", maxSplits: 2, omittingEmptySubsequences: false)
+        XCTAssertGreaterThanOrEqual(parts.count, 3, "Should have namespace__toolname structure")
+    }
+
+    /// Test long namespace with short tool name
+    func testNamespacedToolName_LongNamespaceShortTool() {
+        let namespace = String(repeating: "x", count: 60)  // Very long namespace
+        let toolName = "tool"  // Short tool name
+        let result = namespacedToolName(namespace: namespace, toolName: toolName)
+
+        XCTAssertLessThanOrEqual(result.count, 64, "Should truncate to 64 characters or less")
+        XCTAssertTrue(result.contains("__"), "Should contain delimiter")
+
+        // Tool name should get at least minimum length
+        let components = result.components(separatedBy: "__")
+        XCTAssertEqual(components.count, 2, "Should have exactly 2 parts")
+        XCTAssertGreaterThanOrEqual(components[1].count, 4, "Tool name should be preserved when short")
+    }
+
+    /// Test short namespace with long tool name
+    func testNamespacedToolName_ShortNamespaceLongTool() {
+        let namespace = "srv"  // Short namespace
+        let toolName = String(repeating: "y", count: 70)  // Very long tool name
+        let result = namespacedToolName(namespace: namespace, toolName: toolName)
+
+        XCTAssertLessThanOrEqual(result.count, 64, "Should truncate to 64 characters or less")
+        XCTAssertTrue(result.contains("__"), "Should contain delimiter")
+
+        // Namespace should be preserved when short
+        let components = result.components(separatedBy: "__")
+        XCTAssertEqual(components.count, 2, "Should have exactly 2 parts")
+        XCTAssertEqual(components[0], namespace, "Short namespace should be preserved")
+    }
+
+    /// Test extremely long namespace with minimal tool name
+    func testNamespacedToolName_ExtremelyLongNamespaceMinimalTool() {
+        let namespace = String(repeating: "n", count: 100)  // Extremely long
+        let toolName = "x"  // Minimal tool name
+        let result = namespacedToolName(namespace: namespace, toolName: toolName)
+
+        XCTAssertLessThanOrEqual(result.count, 64, "Should truncate to 64 characters or less")
+        XCTAssertTrue(result.contains("__"), "Should contain delimiter")
+
+        let components = result.components(separatedBy: "__")
+        XCTAssertEqual(components.count, 2, "Should have exactly 2 parts")
+        XCTAssertGreaterThanOrEqual(components[0].count, 8, "Namespace should get at least minimum length")
+        XCTAssertGreaterThanOrEqual(components[1].count, 1, "Tool name should be preserved when very short")
+    }
+
+    /// Test minimal namespace with extremely long tool name
+    func testNamespacedToolName_MinimalNamespaceExtremelyLongTool() {
+        let namespace = "s"  // Minimal namespace
+        let toolName = String(repeating: "t", count: 100)  // Extremely long
+        let result = namespacedToolName(namespace: namespace, toolName: toolName)
+
+        XCTAssertLessThanOrEqual(result.count, 64, "Should truncate to 64 characters or less")
+        XCTAssertTrue(result.contains("__"), "Should contain delimiter")
+
+        let components = result.components(separatedBy: "__")
+        XCTAssertEqual(components.count, 2, "Should have exactly 2 parts")
+        XCTAssertEqual(components[0], namespace, "Short namespace should be preserved")
+        XCTAssertGreaterThanOrEqual(components[1].count, 8, "Tool name should get reasonable space")
+    }
+
+    /// Test proportional allocation when both are long
+    func testNamespacedToolName_ProportionalTruncation() {
+        // Both parts equally long - should get roughly equal space
+        let namespace = String(repeating: "a", count: 50)
+        let toolName = String(repeating: "b", count: 50)
+        let result = namespacedToolName(namespace: namespace, toolName: toolName)
+
+        XCTAssertLessThanOrEqual(result.count, 64, "Should truncate to 64 characters or less")
+
+        let components = result.components(separatedBy: "__")
+        XCTAssertEqual(components.count, 2, "Should have exactly 2 parts")
+
+        let namespacePart = components[0]
+        let toolPart = components[1]
+
+        // With 62 chars available and equal original lengths, allocation should be roughly equal
+        // Allow some variance due to integer division
+        let lengthDiff = abs(namespacePart.count - toolPart.count)
+        XCTAssertLessThanOrEqual(lengthDiff, 2, "Parts should be roughly equal when originals are equal length")
+    }
+
+    /// Test with realistic MCP server names and tool names
+    func testNamespacedToolName_RealisticNames() {
+        let testCases: [(namespace: String, tool: String, shouldTruncate: Bool)] = [
+            ("linear_server", "create_issue", false),
+            ("github", "create_pull_request", false),
+            ("very_long_server_name_with_many_words", "very_long_tool_name_with_descriptive_text", true),
+            ("anthropic_claude_mcp_server", "analyze_code_repository_with_context", true),
+            ("s", "search_through_documentation_and_return_relevant_results_with_context", true),
+        ]
+
+        for (namespace, toolName, shouldTruncate) in testCases {
+            let result = namespacedToolName(namespace: namespace, toolName: toolName)
+            XCTAssertLessThanOrEqual(result.count, 64, "Result should never exceed 64 characters")
+            XCTAssertTrue(result.contains("__"), "Should contain delimiter")
+
+            if !shouldTruncate {
+                let expected = "\(namespace)__\(toolName)"
+                XCTAssertEqual(result, expected, "Short names should not be truncated")
+            }
+        }
+    }
+
+    /// Test that delimiter is always preserved
+    func testNamespacedToolName_DelimiterAlwaysPresent() {
+        let testCases = [
+            (String(repeating: "a", count: 40), String(repeating: "b", count: 40)),
+            (String(repeating: "x", count: 100), String(repeating: "y", count: 100)),
+            ("short", "name"),
+        ]
+
+        for (namespace, toolName) in testCases where !namespace.isEmpty {
+            let result = namespacedToolName(namespace: namespace, toolName: toolName)
+            XCTAssertTrue(result.contains("__"), "Delimiter should always be present for non-empty namespace")
+
+            let delimiterCount = result.components(separatedBy: "__").count - 1
+            XCTAssertEqual(delimiterCount, 1, "Should have exactly one delimiter")
+        }
+    }
+
+    /// Test minimum length guarantees
+    func testNamespacedToolName_MinimumLengthGuarantees() {
+        // Very long namespace, very short tool - both should get minimum space
+        let namespace = String(repeating: "n", count: 80)
+        let toolName = "t"
+        let result = namespacedToolName(namespace: namespace, toolName: toolName)
+
+        let components = result.components(separatedBy: "__")
+        XCTAssertEqual(components.count, 2, "Should have exactly 2 parts")
+
+        // Both parts should get at least 8 chars (or original length if shorter)
+        XCTAssertGreaterThanOrEqual(components[0].count, 8, "Namespace should get minimum 8 chars")
+        XCTAssertGreaterThanOrEqual(components[1].count, 1, "Tool name should be preserved when very short")
+    }
+
+    // MARK: - Sanitize Server Name Tests
+
+    func testSanitizeServerName_BasicAlphanumeric() {
+        XCTAssertEqual(sanitizeServerNameToNamespace("myserver"), "myserver")
+        XCTAssertEqual(sanitizeServerNameToNamespace("MyServer123"), "myserver123")
+    }
+
+    func testSanitizeServerName_WithHyphens() {
+        XCTAssertEqual(sanitizeServerNameToNamespace("my-server"), "my_server")
+        XCTAssertEqual(sanitizeServerNameToNamespace("server-with-many-hyphens"), "server_with_many_hyphens")
+    }
+
+    func testSanitizeServerName_WithUnderscores() {
+        XCTAssertEqual(sanitizeServerNameToNamespace("my_server"), "my_server")
+        XCTAssertEqual(sanitizeServerNameToNamespace("my__server"), "my_server")
+    }
+
+    func testSanitizeServerName_SpecialCharacters() {
+        XCTAssertEqual(sanitizeServerNameToNamespace("my@server!"), "my_server")
+        XCTAssertEqual(sanitizeServerNameToNamespace("server#123$"), "server_123")
+    }
+
+    func testSanitizeServerName_MultipleConsecutiveSpecialChars() {
+        XCTAssertEqual(sanitizeServerNameToNamespace("my---server"), "my_server")
+        XCTAssertEqual(sanitizeServerNameToNamespace("server___test"), "server_test")
+    }
+
+    // MARK: - Unique Namespace Assignment Tests
+
+    func testAssignUniqueNamespaces_NoCollisions() {
+        let servers = ["server1", "server2", "server3"]
+        let result = assignUniqueNamespaces(serverNames: servers)
+
+        XCTAssertEqual(result["server1"], "server1")
+        XCTAssertEqual(result["server2"], "server2")
+        XCTAssertEqual(result["server3"], "server3")
+    }
+
+    func testAssignUniqueNamespaces_WithCollisions() {
+        let servers = ["my-server", "my_server", "my@server"]
+        let result = assignUniqueNamespaces(serverNames: servers)
+
+        // All sanitize to "my_server", so should get suffixes
+        let namespaces = Set(result.values)
+        XCTAssertEqual(namespaces.count, 3, "Should have 3 unique namespaces")
+        XCTAssertTrue(namespaces.contains("my_server"))
+        XCTAssertTrue(namespaces.contains("my_server_2") || namespaces.contains("my_server_3"))
+    }
+
+    func testAssignUniqueNamespaces_Deterministic() {
+        let servers = ["server-a", "server_a", "serverA"]
+        let result1 = assignUniqueNamespaces(serverNames: servers)
+        let result2 = assignUniqueNamespaces(serverNames: servers)
+
+        XCTAssertEqual(result1, result2, "Should produce deterministic results")
+    }
+
+    // MARK: - Parse Namespaced Tool Name Tests
+
+    func testParseNamespacedToolName_ValidFormat() {
+        let namespaceMap = ["server": "my-server"]
+        let result = parseNamespacedToolName("server__tool_name", namespaceToServer: namespaceMap)
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.serverName, "my-server")
+        XCTAssertEqual(result?.toolName, "tool_name")
+    }
+
+    func testParseNamespacedToolName_NoDelimiter() {
+        let namespaceMap = ["server": "my-server"]
+        let result = parseNamespacedToolName("toolname", namespaceToServer: namespaceMap)
+
+        XCTAssertNil(result, "Should return nil when no delimiter present")
+    }
+
+    func testParseNamespacedToolName_UnknownNamespace() {
+        let namespaceMap = ["server": "my-server"]
+        let result = parseNamespacedToolName("unknown__tool_name", namespaceToServer: namespaceMap)
+
+        XCTAssertNil(result, "Should return nil for unknown namespace")
+    }
+
+    func testParseNamespacedToolName_EmptyParts() {
+        let namespaceMap = ["server": "my-server"]
+
+        XCTAssertNil(parseNamespacedToolName("__tool", namespaceToServer: namespaceMap))
+        XCTAssertNil(parseNamespacedToolName("server__", namespaceToServer: namespaceMap))
+    }
+}

--- a/Amazon Bedrock Client for Mac/Views/MessageBarView.swift
+++ b/Amazon Bedrock Client for Mac/Views/MessageBarView.swift
@@ -696,7 +696,7 @@ struct AdvancedOptionsMenu: View {
                     } label: {
                         Label(tool.toolName, systemImage: "bolt.fill")
                     }
-                    .help(tool.description)
+                    .help("\(tool.description)\nServer: \(tool.serverName)")
                 }
             }
             

--- a/Amazon Bedrock Client for Mac/Views/MessageBarView.swift
+++ b/Amazon Bedrock Client for Mac/Views/MessageBarView.swift
@@ -694,7 +694,7 @@ struct AdvancedOptionsMenu: View {
                 ForEach(MCPManager.shared.toolInfos) { tool in
                     Button {
                     } label: {
-                        Label(tool.toolName, systemImage: "bolt.fill")
+                        Label(tool.displayName, systemImage: "bolt.fill")
                     }
                     .help("\(tool.description)\nServer: \(tool.serverName)")
                 }

--- a/Amazon Bedrock Client for Mac/Views/SettingsView.swift
+++ b/Amazon Bedrock Client for Mac/Views/SettingsView.swift
@@ -1211,9 +1211,17 @@ struct ServerFormView: View {
         errorMessage = nil
     }
     
+    private func cleanServerName(_ name: String) -> String {
+        return name
+            .replacingOccurrences(of: "-mcp", with: "", options: .caseInsensitive)
+            .replacingOccurrences(of: "_mcp", with: "", options: .caseInsensitive)
+            .trimmingCharacters(in: .whitespaces)
+    }
+
     private func saveServer() {
         guard validateInputs() else { return }
-        
+
+        let cleanedName = cleanServerName(name)
         let serverConfig: MCPServerConfig
         
         switch transportType {
@@ -1227,7 +1235,7 @@ struct ServerFormView: View {
             }
             
             serverConfig = MCPServerConfig(
-                name: name,
+                name: cleanedName,
                 transportType: .stdio,
                 command: command,
                 args: argArray,
@@ -1244,7 +1252,7 @@ struct ServerFormView: View {
             }
             
             serverConfig = MCPServerConfig(
-                name: name,
+                name: cleanedName,
                 transportType: .http,
                 url: url,
                 headers: headersDict,
@@ -1260,7 +1268,7 @@ struct ServerFormView: View {
             isPresented = false
         } else {
             // Add new server
-            if !mcpManager.servers.contains(where: { $0.name == name }) {
+            if !mcpManager.servers.contains(where: { $0.name == cleanedName }) {
                 mcpManager.addServer(serverConfig)
                 isPresented = false
             } else {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Implement unique namespace for MCP servers to avoid Bedrock exceptions with duplicate tool names. For example, if I am using the Linear and Github MCP servers, they both use `list_issues` which causes a conflict. 

- [x]  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
